### PR TITLE
Fix whitelist support for Ely.by / alternative providers on 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.13-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -32,14 +32,14 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+		sourceCompatibility = JavaVersion.VERSION_21
+		targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,11 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.15.11
+
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.18.1
+loom_version=1.13-SNAPSHOT
 
 # Mod Properties
 mod_version=1.1.1
@@ -14,4 +16,4 @@ maven_group=one.ggsky
 archives_base_name=alternative-auth
 
 # Dependencies
-fabric_version=0.117.0+1.21.4
+fabric_version=0.138.3+1.21.10

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/one/ggsky/alternativeauth/mixin/FindProfileByNameMixin.java
+++ b/src/main/java/one/ggsky/alternativeauth/mixin/FindProfileByNameMixin.java
@@ -1,0 +1,61 @@
+package one.ggsky.alternativeauth.mixin;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.HttpAuthenticationService;
+import com.mojang.authlib.exceptions.MinecraftClientException;
+import com.mojang.authlib.minecraft.client.MinecraftClient;
+import com.mojang.authlib.yggdrasil.YggdrasilGameProfileRepository;
+import com.mojang.authlib.yggdrasil.response.NameAndId;
+import com.mojang.authlib.yggdrasil.response.ProfileSearchResultsResponse;
+import one.ggsky.alternativeauth.config.AlternativeAuthConfig;
+import one.ggsky.alternativeauth.config.AlternativeAuthConfigManager;
+import one.ggsky.alternativeauth.config.AlternativeAuthProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.net.Proxy;
+import java.net.URL;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@Mixin(value = YggdrasilGameProfileRepository.class, remap = false)
+public class FindProfileByNameMixin {
+
+    @Inject(method = "findProfileByName", at = @At("HEAD"), cancellable = true)
+    private void alternativeAuth$findProfileByName(String name,
+                                                   CallbackInfoReturnable<Optional<GameProfile>> cir) {
+        if (name == null || name.isEmpty()) {
+            return;
+        }
+
+        AlternativeAuthConfig config = AlternativeAuthConfigManager.getConfig();
+
+        final MinecraftClient client = MinecraftClient.unauthenticated(Proxy.NO_PROXY);
+
+        // просто сразу в lowerCase вместо normalizeName()
+        final List<String> request = List.of(name.toLowerCase(Locale.ROOT));
+
+        for (AlternativeAuthProvider provider : config.getProviders()) {
+            try {
+                URL url = HttpAuthenticationService.constantURL(provider.getProfilesUrl());
+                ProfileSearchResultsResponse response =
+                        client.post(url, request, ProfileSearchResultsResponse.class);
+
+                if (response != null && !response.profiles().isEmpty()) {
+                    NameAndId p = response.profiles().get(0);
+                    GameProfile gameProfile = new GameProfile(p.id(), p.name());
+                    cir.setReturnValue(Optional.of(gameProfile));
+                    return;
+                }
+
+            } catch (MinecraftClientException ignored) {
+                // просто пробуем следующий провайдер
+            }
+        }
+
+        cir.setReturnValue(Optional.empty());
+    }
+}

--- a/src/main/resources/alternative-auth.mixins.json
+++ b/src/main/resources/alternative-auth.mixins.json
@@ -2,7 +2,11 @@
     "required": true,
     "package": "one.ggsky.alternativeauth.mixin",
     "compatibilityLevel": "JAVA_17",
-    "mixins": ["CheckAuthenticationMixin", "FindProfilesByNamesMixin"],
+    "mixins": [
+        "CheckAuthenticationMixin",
+        "FindProfilesByNamesMixin",
+        "FindProfileByNameMixin"
+        ],
     "injectors": {
         "defaultRequire": 1
     }


### PR DESCRIPTION
Minecraft 1.21.10+ changed whitelist behavior to use
YggdrasilGameProfileRepository#findProfileByName.
The mod only patched findProfilesByNames, so `/whitelist add <name>`
failed for Ely.by / non-Mojang accounts.

This PR adds FindProfileByNameMixin with lookup logic identical to
FindProfilesByNamesMixin, restoring whitelist support for Ely.by and
other configured providers.

Tested on:
- Fabric 1.21.11
- Mojang account
- Ely.by account
- whitelist add works 
