### PR TITLE
Update to Minecraft 26.2 + fix profile key kick for third-party auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  MC_VERSIONS: "26.1"
+  MC_VERSIONS: "26.2"
   JAVA_VERSION: "25"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.3.1] - 2026-06-20
+
+- Added `ChatSessionUpdateMixin` to prevent players with third-party authentication from being kicked for invalid profile key signatures.
+- Bumped to 1.3.1.
+
+---
+
 ## [1.3.0] - 2026-06-20
 
 - Updated to support Minecraft 26.2 ("Chaos Cubed").

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [1.3.0] - 2026-03-28
+## [1.3.0] - 2026-06-20
 
-- Updated to support 26.1
+- Updated to support Minecraft 26.2 ("Chaos Cubed").
+- Bumped Fabric Loader to 0.19.3, Fabric API to 0.152.2+26.2, Fabric Loom to 1.17-SNAPSHOT.
+- Bumped Java compile target from 21 to 25.
+- Bumped Gradle wrapper from 9.4.1 to 9.5.1.
+- Fixed `fabric.mod.json` dependency version constraints.
 - Added new `preventFallbackIfPlayerExists` option.
 - Added config version system and reworked config related stuff.
 - Added more detailed debug logs.
 - Internal refactors and improvements.
-- Bumped to 1.3.0.
 
 --- 
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,14 +30,14 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,14 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1
-loader_version=0.18.5
-loom_version=1.15-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.3.0+26.1
+mod_version=1.3.0+26.2
 maven_group=one.ggsky
 archives_base_name=alternative-auth
 
 # Dependencies
-fabric_version=0.144.3+26.1
+fabric_version=0.152.2+26.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.19.3
 loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.3.0+26.2
+mod_version=1.3.1+26.2
 maven_group=one.ggsky
 archives_base_name=alternative-auth
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/one/ggsky/alternativeauth/mixin/ChatSessionUpdateMixin.java
+++ b/src/main/java/one/ggsky/alternativeauth/mixin/ChatSessionUpdateMixin.java
@@ -1,0 +1,27 @@
+package one.ggsky.alternativeauth.mixin;
+
+import net.minecraft.network.protocol.game.ServerboundChatSessionUpdatePacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import one.ggsky.alternativeauth.logger.AlternativeAuthLogger;
+import one.ggsky.alternativeauth.logger.AlternativeAuthLoggerManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerGamePacketListenerImpl.class)
+public class ChatSessionUpdateMixin {
+    @Unique
+    private static final AlternativeAuthLogger LOGGER = AlternativeAuthLoggerManager.getLogger();
+
+    @Inject(
+        at = @At("HEAD"),
+        method = "handleChatSessionUpdate",
+        cancellable = true
+    )
+    private void handleChatSessionUpdate(ServerboundChatSessionUpdatePacket packet, CallbackInfo ci) {
+        LOGGER.debug("Cancelling chat session update to prevent profile key validation kick");
+        ci.cancel();
+    }
+}

--- a/src/main/resources/alternative-auth.mixins.json
+++ b/src/main/resources/alternative-auth.mixins.json
@@ -5,7 +5,8 @@
     "mixins": [
         "HasJoinedServerMixin",
         "FindProfileByNameMixin",
-        "FindProfilesByNamesMixin"
+        "FindProfilesByNamesMixin",
+        "ChatSessionUpdateMixin"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,7 +17,9 @@
     },
     "mixins": ["alternative-auth.mixins.json"],
     "depends": {
-        "minecraft": [">=1.21.9", "<=1.21.11"],
+        "fabricloader": ">=0.19.3",
+        "minecraft": "~26.2",
+        "java": ">=25",
         "fabric-api": "*"
     }
 }


### PR DESCRIPTION
**Minecraft 26.2 support** (334e80d)

**Profile key validation fix** (122d11b)