### PR TITLE
Update to Minecraft 26.2 + fix profile key kick for third-party auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  MC_VERSIONS: "26.1"
+  MC_VERSIONS: "26.2"
   JAVA_VERSION: "25"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.3.2] - 2026-06-22
+
+- Added `DedicatedServerMixin` to override `enforceSecureProfile` to `false`, fixing chat being disabled for all players when `ChatSessionUpdateMixin` is active.
+- Bumped to 1.3.2.
+
+---
+
 ## [1.3.1] - 2026-06-20
 
 - Added `ChatSessionUpdateMixin` to prevent players with third-party authentication from being kicked for invalid profile key signatures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.3.1] - 2026-06-20
+
+- Added `ChatSessionUpdateMixin` to prevent players with third-party authentication from being kicked for invalid profile key signatures.
+- Bumped to 1.3.1.
+
+---
+
 ## [1.3.0] - 2026-06-20
 
 - Updated to support Minecraft 26.2 ("Chaos Cubed").

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [1.3.0] - 2026-03-28
+## [1.3.0] - 2026-06-20
 
-- Updated to support 26.1
+- Updated to support Minecraft 26.2 ("Chaos Cubed").
+- Bumped Fabric Loader to 0.19.3, Fabric API to 0.152.2+26.2, Fabric Loom to 1.17-SNAPSHOT.
+- Bumped Java compile target from 21 to 25.
+- Bumped Gradle wrapper from 9.4.1 to 9.5.1.
+- Fixed `fabric.mod.json` dependency version constraints.
 - Added new `preventFallbackIfPlayerExists` option.
 - Added config version system and reworked config related stuff.
 - Added more detailed debug logs.
 - Internal refactors and improvements.
-- Bumped to 1.3.0.
 
 --- 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Alternative Authentication is a server-side mod that allows multiple third-party
 **Requirements:**
 
 - `online-mode=true` in `server.properties`
-- `enforce-secure-profile=false` is recommended, players joining via third-party providers don't have signed chat keys
+- `enforce-secure-profile=false` is handled automatically by the mod, players joining via third-party providers don't have signed chat keys
 
 > **Server-side only.** Players using a third-party auth provider on the client need a compatible launcher or injector.
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,14 +30,14 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,14 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1
-loader_version=0.18.5
-loom_version=1.15-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.3.0+26.1
+mod_version=1.3.0+26.2
 maven_group=one.ggsky
 archives_base_name=alternative-auth
 
 # Dependencies
-fabric_version=0.144.3+26.1
+fabric_version=0.152.2+26.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.19.3
 loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.3.1+26.2
+mod_version=1.3.2+26.2
 maven_group=one.ggsky
 archives_base_name=alternative-auth
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.19.3
 loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.3.0+26.2
+mod_version=1.3.1+26.2
 maven_group=one.ggsky
 archives_base_name=alternative-auth
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/one/ggsky/alternativeauth/mixin/ChatSessionUpdateMixin.java
+++ b/src/main/java/one/ggsky/alternativeauth/mixin/ChatSessionUpdateMixin.java
@@ -1,0 +1,27 @@
+package one.ggsky.alternativeauth.mixin;
+
+import net.minecraft.network.protocol.game.ServerboundChatSessionUpdatePacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import one.ggsky.alternativeauth.logger.AlternativeAuthLogger;
+import one.ggsky.alternativeauth.logger.AlternativeAuthLoggerManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerGamePacketListenerImpl.class)
+public class ChatSessionUpdateMixin {
+    @Unique
+    private static final AlternativeAuthLogger LOGGER = AlternativeAuthLoggerManager.getLogger();
+
+    @Inject(
+        at = @At("HEAD"),
+        method = "handleChatSessionUpdate",
+        cancellable = true
+    )
+    private void handleChatSessionUpdate(ServerboundChatSessionUpdatePacket packet, CallbackInfo ci) {
+        LOGGER.debug("Cancelling chat session update to prevent profile key validation kick");
+        ci.cancel();
+    }
+}

--- a/src/main/java/one/ggsky/alternativeauth/mixin/DedicatedServerMixin.java
+++ b/src/main/java/one/ggsky/alternativeauth/mixin/DedicatedServerMixin.java
@@ -1,0 +1,26 @@
+package one.ggsky.alternativeauth.mixin;
+
+import net.minecraft.server.dedicated.DedicatedServer;
+import one.ggsky.alternativeauth.logger.AlternativeAuthLogger;
+import one.ggsky.alternativeauth.logger.AlternativeAuthLoggerManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(DedicatedServer.class)
+public class DedicatedServerMixin {
+    @Unique
+    private static final AlternativeAuthLogger LOGGER = AlternativeAuthLoggerManager.getLogger();
+
+    @Inject(
+        at = @At("HEAD"),
+        method = "enforceSecureProfile",
+        cancellable = true
+    )
+    private void onEnforceSecureProfile(CallbackInfoReturnable<Boolean> cir) {
+        LOGGER.debug("Overriding enforceSecureProfile to false for alternative authentication compatibility");
+        cir.setReturnValue(false);
+    }
+}

--- a/src/main/resources/alternative-auth.mixins.json
+++ b/src/main/resources/alternative-auth.mixins.json
@@ -6,7 +6,8 @@
         "HasJoinedServerMixin",
         "FindProfileByNameMixin",
         "FindProfilesByNamesMixin",
-        "ChatSessionUpdateMixin"
+        "ChatSessionUpdateMixin",
+        "DedicatedServerMixin"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/src/main/resources/alternative-auth.mixins.json
+++ b/src/main/resources/alternative-auth.mixins.json
@@ -5,7 +5,8 @@
     "mixins": [
         "HasJoinedServerMixin",
         "FindProfileByNameMixin",
-        "FindProfilesByNamesMixin"
+        "FindProfilesByNamesMixin",
+        "ChatSessionUpdateMixin"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,7 +17,9 @@
     },
     "mixins": ["alternative-auth.mixins.json"],
     "depends": {
-        "minecraft": [">=1.21.9", "<=1.21.11"],
+        "fabricloader": ">=0.19.3",
+        "minecraft": "~26.2",
+        "java": ">=25",
         "fabric-api": "*"
     }
 }


### PR DESCRIPTION
Hey! I've been using this mod on my server with Ely.by players and ran into two things while updating to 26.2, so I figured I'd open a PR with the fixes.

This should probably be merged into a new 26.2 branch rather than 26.1, to keep the per-version branch layout the repo already uses.

**What's changed:**

**Minecraft 26.2 support** (334e80d)
- Updated minecraft_version, loader_version, loom_version, fabric_version to match the fabric-example-mod 26.2 branch
- Bumped Java compile target from 21 to 25 (MC 26.2 requires it)
- Bumped Gradle wrapper from 9.4.1 to 9.5.1 (Loom 1.17 requires it)
- Fixed fabric.mod.json depends. The old minecraft range was still set to 1.21.9-1.21.11, updated to ~26.2 with proper fabricloader and java constraints

**Profile key validation fix** (122d11b)
- Players authed through third-party providers get kicked about 3 seconds after joining with "Invalid signature for profile public key" even when enforce-secure-profile=false is set
- This happens because ServerGamePacketListenerImpl.handleChatSessionUpdate() validates the profile key signature unconditionally. enforce-secure-profile only controls whether a missing key is rejected during login, not whether an invalid one is rejected later
- Added ChatSessionUpdateMixin that cancels handleChatSessionUpdate at HEAD, same approach No Chat Reports uses
- Tested on my server with Ely.by players, no more kicks

Let me know if anything needs adjusting!